### PR TITLE
Add global command palette

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,34 @@
+import CommandK, { type CommandKItem } from "@/components/command/CommandK";
 import Portfolio from "./Portfolio";
 
+const COMMAND_ITEMS: CommandKItem[] = [
+  {
+    label: "Home",
+    path: "/",
+    keywords: ["home", "start", "hero", "메인"],
+  },
+  {
+    label: "Projects",
+    path: "/#projects",
+    keywords: ["project", "work", "case study", "프로젝트"],
+  },
+  {
+    label: "About",
+    path: "/#about",
+    keywords: ["about", "profile", "career", "소개"],
+  },
+  {
+    label: "Contact",
+    path: "/#contact",
+    keywords: ["contact", "email", "연락", "문의"],
+  },
+];
+
 export default function App() {
-  return <Portfolio />;
+  return (
+    <>
+      <CommandK items={COMMAND_ITEMS} />
+      <Portfolio />
+    </>
+  );
 }

--- a/src/components/command/CommandK.tsx
+++ b/src/components/command/CommandK.tsx
@@ -1,0 +1,194 @@
+import React from "react"
+import {
+  Command,
+  CommandDialog,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandShortcut,
+} from "@/components/ui/command"
+import { useLocation, useNavigate } from "react-router-dom"
+import { ArrowUpRight, Home, Info, Mail, PanelsTopLeft } from "lucide-react"
+
+type CommandKItem = {
+  label: string
+  path: string
+  keywords?: string[]
+  description?: string
+}
+
+type CommandKProps = {
+  items: CommandKItem[]
+}
+
+function getSearchableText(item: CommandKItem) {
+  const base = [item.label, item.path, ...(item.keywords ?? [])]
+    .join(" ")
+    .toLowerCase()
+  return base
+}
+
+const iconMap: Record<string, React.ReactNode> = {
+  home: <Home className="h-4 w-4" />,
+  projects: <PanelsTopLeft className="h-4 w-4" />,
+  about: <Info className="h-4 w-4" />,
+  contact: <Mail className="h-4 w-4" />,
+}
+
+function getIconForLabel(label: string) {
+  const key = label.trim().toLowerCase()
+  return iconMap[key] ?? <ArrowUpRight className="h-4 w-4" />
+}
+
+export default function CommandK({ items }: CommandKProps) {
+  const navigate = useNavigate()
+  const location = useLocation()
+  const [open, setOpen] = React.useState(false)
+  const [search, setSearch] = React.useState("")
+  const [activeIndex, setActiveIndex] = React.useState(0)
+  const inputRef = React.useRef<HTMLInputElement>(null)
+  const [isMac, setIsMac] = React.useState(false)
+
+  React.useEffect(() => {
+    if (typeof window === "undefined") return
+    setIsMac(/Mac|iPhone|iPad|iPod/.test(window.navigator.platform))
+  }, [])
+
+  React.useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "k") {
+        event.preventDefault()
+        setOpen((prev) => !prev)
+      }
+    }
+
+    window.addEventListener("keydown", handleKeyDown)
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown)
+    }
+  }, [])
+
+  React.useEffect(() => {
+    if (!open) return
+    const timer = window.setTimeout(() => {
+      inputRef.current?.focus()
+    }, 10)
+
+    return () => window.clearTimeout(timer)
+  }, [open])
+
+  React.useEffect(() => {
+    if (!open) return
+    setActiveIndex(0)
+  }, [open, search])
+
+  const filteredItems = React.useMemo(() => {
+    const trimmed = search.trim().toLowerCase()
+    if (!trimmed) return items
+
+    return items.filter((item) => getSearchableText(item).includes(trimmed))
+  }, [items, search])
+
+  React.useEffect(() => {
+    if (activeIndex >= filteredItems.length) {
+      setActiveIndex(filteredItems.length === 0 ? 0 : filteredItems.length - 1)
+    }
+  }, [filteredItems, activeIndex])
+
+  const handleSelect = React.useCallback(
+    (item: CommandKItem) => {
+      const target = item.path || "/"
+      const currentFullPath = `${location.pathname}${location.hash}`
+      const shouldReplace = currentFullPath === target
+      setOpen(false)
+      navigate(target, { replace: shouldReplace })
+
+      if (typeof window === "undefined") return
+
+      const hashIndex = target.indexOf("#")
+      if (hashIndex >= 0) {
+        const elementId = target.slice(hashIndex + 1)
+        if (elementId) {
+          window.requestAnimationFrame(() => {
+            document
+              .getElementById(elementId)
+              ?.scrollIntoView({ behavior: "smooth", block: "start" })
+          })
+        }
+      } else {
+        window.requestAnimationFrame(() => {
+          window.scrollTo({ top: 0, behavior: "smooth" })
+        })
+      }
+    },
+    [location.hash, location.pathname, navigate]
+  )
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (filteredItems.length === 0) return
+
+    if (event.key === "ArrowDown") {
+      event.preventDefault()
+      setActiveIndex((prev) => Math.min(prev + 1, filteredItems.length - 1))
+    } else if (event.key === "ArrowUp") {
+      event.preventDefault()
+      setActiveIndex((prev) => Math.max(prev - 1, 0))
+    } else if (event.key === "Enter") {
+      event.preventDefault()
+      const item = filteredItems[activeIndex]
+      if (item) {
+        handleSelect(item)
+      }
+    }
+  }
+
+  return (
+    <CommandDialog open={open} onOpenChange={setOpen}>
+      <Command onKeyDown={handleKeyDown} className="bg-card/95">
+        <div className="flex items-center justify-between px-3 pt-3 text-xs text-muted-foreground">
+          <span>찾고 싶은 섹션이나 키워드를 입력하세요</span>
+          <span className="font-mono text-[11px] text-muted-foreground/80">{isMac ? "⌘" : "Ctrl"}+K</span>
+        </div>
+        <CommandInput
+          ref={inputRef}
+          value={search}
+          onChange={(event) => setSearch(event.target.value)}
+          placeholder="Search pages, sections, or keywords..."
+          aria-label="Command palette search"
+        />
+        <CommandList>
+          {filteredItems.length === 0 ? (
+            <CommandEmpty>일치하는 결과가 없습니다.</CommandEmpty>
+          ) : (
+            <CommandGroup>
+              {filteredItems.map((item, index) => (
+                <CommandItem
+                  key={item.label}
+                  active={index === activeIndex}
+                  onClick={() => handleSelect(item)}
+                >
+                  <span className="flex h-8 w-8 items-center justify-center rounded-md border border-border bg-muted text-muted-foreground">
+                    {getIconForLabel(item.label)}
+                  </span>
+                  <span className="flex flex-1 flex-col">
+                    <span className="text-sm font-medium">{item.label}</span>
+                    {item.keywords && item.keywords.length > 0 ? (
+                      <span className="text-[11px] text-muted-foreground/80">
+                        {item.keywords.join(" · ")}
+                      </span>
+                    ) : null}
+                  </span>
+                  <CommandShortcut>{item.path.replace("/#", "#")}</CommandShortcut>
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          )}
+        </CommandList>
+      </Command>
+    </CommandDialog>
+  )
+}
+
+export type { CommandKItem }

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -1,0 +1,192 @@
+import React from "react"
+import { createPortal } from "react-dom"
+import { cn } from "@/lib/utils"
+
+type CommandDialogProps = {
+  open: boolean
+  onOpenChange?: (open: boolean) => void
+  children: React.ReactNode
+}
+
+export function CommandDialog({ open, onOpenChange, children }: CommandDialogProps) {
+  React.useEffect(() => {
+    if (!open || typeof document === "undefined") return
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        onOpenChange?.(false)
+      }
+    }
+
+    window.addEventListener("keydown", handleKeyDown)
+    const { body } = document
+    const previousOverflow = body.style.overflow
+    body.style.overflow = "hidden"
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown)
+      body.style.overflow = previousOverflow
+    }
+  }, [open, onOpenChange])
+
+  if (!open) return null
+
+  return createPortal(
+    <div
+      aria-modal="true"
+      role="dialog"
+      className="fixed inset-0 z-50 flex items-start justify-center bg-background/80 backdrop-blur-sm px-4 py-24"
+      onClick={() => onOpenChange?.(false)}
+    >
+      <div
+        className="relative w-full max-w-xl"
+        onClick={(event) => event.stopPropagation()}
+      >
+        {children}
+      </div>
+    </div>,
+    document.body
+  )
+}
+
+type CommandProps = React.HTMLAttributes<HTMLDivElement>
+
+export const Command = React.forwardRef<HTMLDivElement, CommandProps>(function Command(
+  { className, ...props },
+  ref
+) {
+  return (
+    <div
+      ref={ref}
+      className={cn(
+        "flex w-full flex-col overflow-hidden rounded-xl border border-border bg-card text-card-foreground shadow-2xl",
+        className
+      )}
+      {...props}
+    />
+  )
+})
+
+type CommandInputProps = React.InputHTMLAttributes<HTMLInputElement>
+
+export const CommandInput = React.forwardRef<HTMLInputElement, CommandInputProps>(function CommandInput(
+  { className, ...props },
+  ref
+) {
+  return (
+    <div className="flex items-center border-b border-border bg-muted/40 px-3">
+      <input
+        ref={ref}
+        className={cn(
+          "h-11 w-full bg-transparent text-sm text-foreground placeholder:text-muted-foreground focus:outline-none",
+          className
+        )}
+        {...props}
+      />
+    </div>
+  )
+})
+
+type CommandListProps = React.HTMLAttributes<HTMLDivElement>
+
+export const CommandList = React.forwardRef<HTMLDivElement, CommandListProps>(function CommandList(
+  { className, ...props },
+  ref
+) {
+  return (
+    <div
+      ref={ref}
+      role="listbox"
+      className={cn("max-h-72 overflow-y-auto py-2", className)}
+      {...props}
+    />
+  )
+})
+
+type CommandEmptyProps = React.HTMLAttributes<HTMLDivElement>
+
+export const CommandEmpty = React.forwardRef<HTMLDivElement, CommandEmptyProps>(function CommandEmpty(
+  { className, ...props },
+  ref
+) {
+  return (
+    <div
+      ref={ref}
+      className={cn("px-4 py-6 text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+})
+
+type CommandGroupProps = React.HTMLAttributes<HTMLDivElement>
+
+export const CommandGroup = React.forwardRef<HTMLDivElement, CommandGroupProps>(function CommandGroup(
+  { className, ...props },
+  ref
+) {
+  return (
+    <div
+      ref={ref}
+      className={cn("px-2 py-1.5 text-sm", className)}
+      {...props}
+    />
+  )
+})
+
+type CommandItemProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
+  active?: boolean
+}
+
+export const CommandItem = React.forwardRef<HTMLButtonElement, CommandItemProps>(function CommandItem(
+  { className, active, children, onClick, ...props },
+  ref
+) {
+  return (
+    <button
+      ref={ref}
+      role="option"
+      className={cn(
+        "group flex w-full cursor-pointer items-center gap-3 rounded-md px-3 py-2 text-left text-sm transition-colors",
+        active ? "bg-primary/15 text-primary" : "text-foreground hover:bg-muted",
+        className
+      )}
+      data-active={active ? "true" : undefined}
+      aria-selected={active}
+      type="button"
+      onClick={onClick}
+      {...props}
+    >
+      {children}
+    </button>
+  )
+})
+
+type CommandSeparatorProps = React.HTMLAttributes<HTMLDivElement>
+
+export const CommandSeparator = React.forwardRef<HTMLDivElement, CommandSeparatorProps>(function CommandSeparator(
+  { className, ...props },
+  ref
+) {
+  return (
+    <div
+      ref={ref}
+      role="separator"
+      className={cn("mx-2 my-1 h-px bg-border", className)}
+      {...props}
+    />
+  )
+})
+
+type CommandShortcutProps = React.HTMLAttributes<HTMLSpanElement>
+
+export const CommandShortcut = React.forwardRef<HTMLSpanElement, CommandShortcutProps>(function CommandShortcut(
+  { className, ...props },
+  ref
+) {
+  return (
+    <span
+      ref={ref}
+      className={cn("ml-auto text-xs text-muted-foreground", className)}
+      {...props}
+    />
+  )
+})

--- a/src/lib/react-router-dom.tsx
+++ b/src/lib/react-router-dom.tsx
@@ -1,0 +1,90 @@
+/* eslint-disable react-refresh/only-export-components */
+import React from "react"
+
+type LocationLike = {
+  pathname: string
+  search: string
+  hash: string
+}
+
+type NavigateOptions = {
+  replace?: boolean
+  state?: unknown
+}
+
+type RouterContextValue = {
+  location: LocationLike
+  navigate: (to: string, options?: NavigateOptions) => void
+}
+
+const defaultLocation: LocationLike = {
+  pathname: "/",
+  search: "",
+  hash: "",
+}
+
+const RouterContext = React.createContext<RouterContextValue | null>(null)
+
+function getWindowLocation(): LocationLike {
+  if (typeof window === "undefined") {
+    return defaultLocation
+  }
+
+  return {
+    pathname: window.location.pathname,
+    search: window.location.search,
+    hash: window.location.hash,
+  }
+}
+
+export function BrowserRouter({ children }: { children: React.ReactNode }) {
+  const [location, setLocation] = React.useState<LocationLike>(() => getWindowLocation())
+
+  React.useEffect(() => {
+    const handlePopState = () => {
+      setLocation(getWindowLocation())
+    }
+
+    window.addEventListener("popstate", handlePopState)
+    return () => {
+      window.removeEventListener("popstate", handlePopState)
+    }
+  }, [])
+
+  const navigate = React.useCallback((to: string, options?: NavigateOptions) => {
+    if (typeof window === "undefined") return
+
+    const nextUrl = to.startsWith("http") ? to : to || "/"
+    if (options?.replace) {
+      window.history.replaceState(options.state ?? null, "", nextUrl)
+    } else {
+      window.history.pushState(options?.state ?? null, "", nextUrl)
+    }
+
+    setLocation(getWindowLocation())
+  }, [])
+
+  const value = React.useMemo<RouterContextValue>(() => ({ location, navigate }), [location, navigate])
+
+  return <RouterContext.Provider value={value}>{children}</RouterContext.Provider>
+}
+
+export function useNavigate() {
+  const context = React.useContext(RouterContext)
+  if (!context) {
+    throw new Error("useNavigate must be used within a BrowserRouter")
+  }
+
+  return context.navigate
+}
+
+export function useLocation() {
+  const context = React.useContext(RouterContext)
+  if (!context) {
+    throw new Error("useLocation must be used within a BrowserRouter")
+  }
+
+  return context.location
+}
+
+export type { NavigateOptions }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,9 +3,12 @@ import { createRoot } from 'react-dom/client'
 import './index.css'
 //import App from './App.tsx'
 import App from './App'
+import { BrowserRouter } from 'react-router-dom'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </StrictMode>,
 )

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -13,7 +13,8 @@
 
     "baseUrl": ".",
     "paths": {
-      "@/*": ["src/*"]
+      "@/*": ["src/*"],
+      "react-router-dom": ["src/lib/react-router-dom"]
     },
 
     "types": ["vite/client", "node"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,8 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./src/*"],
+      "react-router-dom": ["./src/lib/react-router-dom"]
     }
   }
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': path.resolve(__dirname, 'src'), // ← 핵심
+      'react-router-dom': path.resolve(__dirname, 'src/lib/react-router-dom'),
     },
   },
 })


### PR DESCRIPTION
## Summary
- add a reusable CommandK component that opens via ⌘K/Ctrl+K and filters navigation entries
- wire the command palette into App with navigation targets for Home, Projects, About, and Contact
- introduce a lightweight internal router shim so the command palette can trigger navigation without external deps

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d4c1759b488329957b28c6d76bd815