### PR TITLE
Add project card skeleton loading state

### DIFF
--- a/src/Portfolio.tsx
+++ b/src/Portfolio.tsx
@@ -21,6 +21,7 @@ import { Separator } from "@/components/ui/separator";
 
 import { ThemeToggle } from "@/components/ThemeToggle";
 
+import CardSkeleton from "@/components/skeleton/CardSkeleton";
 import { Input } from "@/components/ui/input";
 import { Search, X } from "lucide-react";
 
@@ -139,10 +140,20 @@ export default function Portfolio() {
   // Portfolio() 내부, return 위쪽에 추가
   const [query, setQuery] = React.useState("");
   const [activeTags, setActiveTags] = React.useState<Set<string>>(new Set());
+  const [projects, setProjects] = React.useState<Project[]>([]);
+  const [isLoading, setIsLoading] = React.useState(true);
+
+  React.useEffect(() => {
+    setProjects(PROJECTS);
+    setIsLoading(false);
+  }, []);
 
   const filtered = React.useMemo(() => {
+    if (!projects.length) {
+      return [];
+    }
     const q = query.trim().toLowerCase();
-    return PROJECTS.filter((p) => {
+    return projects.filter((p) => {
       const matchesQuery =
         !q ||
         p.title.toLowerCase().includes(q) ||
@@ -155,7 +166,7 @@ export default function Portfolio() {
 
       return matchesQuery && matchesTags;
     });
-  }, [query, activeTags]);
+  }, [projects, query, activeTags]);
   return (
     <div className="relative min-h-screen overflow-hidden bg-background text-foreground">
       <AnimatedBackground />
@@ -449,19 +460,31 @@ export default function Portfolio() {
 
           {/* 결과 요약 */}
           <div className="text-sm text-muted-foreground">
-            {filtered.length}개 결과
-            {query && <> · “{query}”</>}
-            {!!activeTags.size && (
+            {isLoading ? (
+              <>프로젝트 로딩 중...</>
+            ) : (
               <>
-                {" "}
-                · 태그: {Array.from(activeTags).join(", ")}
+                {filtered.length}개 결과
+                {query && <> · “{query}”</>}
+                {!!activeTags.size && (
+                  <>
+                    {" "}
+                    · 태그: {Array.from(activeTags).join(", ")}
+                  </>
+                )}
               </>
             )}
           </div>
         </div>
 
         {/* 결과 카드 그리드 */}
-        {filtered.length ? (
+        {isLoading ? (
+          <div className="grid md:grid-cols-3 gap-6">
+            {Array.from({ length: 6 }).map((_, idx) => (
+              <CardSkeleton key={idx} />
+            ))}
+          </div>
+        ) : filtered.length ? (
           <div className="grid md:grid-cols-3 gap-6">
             {filtered.map((p, idx) => (
               <motion.div

--- a/src/components/skeleton/CardSkeleton.tsx
+++ b/src/components/skeleton/CardSkeleton.tsx
@@ -1,0 +1,31 @@
+import { Card, CardContent } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+
+interface CardSkeletonProps {
+  className?: string;
+}
+
+export default function CardSkeleton({ className }: CardSkeletonProps) {
+  return (
+    <Card
+      aria-hidden
+      className={cn(
+        "h-full overflow-hidden rounded-2xl border border-primary/10 bg-gradient-to-br from-background/90 via-muted/20 to-background/95",
+        className,
+      )}
+    >
+      <CardContent className="flex h-full flex-col justify-between gap-6 p-6">
+        <div className="space-y-5">
+          <div className="skeleton h-40 w-full rounded-xl" aria-hidden />
+          <div className="space-y-3">
+            <div className="skeleton h-4 w-3/4" aria-hidden />
+            <div className="skeleton h-4 w-1/2" aria-hidden />
+          </div>
+        </div>
+        <div className="flex justify-end">
+          <div className="skeleton h-9 w-24 rounded-full" aria-hidden />
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -67,3 +67,9 @@
     background-color: hsl(var(--primary) / 0.15);
   }
 }
+
+@layer utilities {
+  .skeleton {
+    @apply animate-pulse rounded-xl bg-muted/70;
+  }
+}


### PR DESCRIPTION
## Summary
- add a reusable card skeleton component and utility class for pulse animation
- render skeleton placeholders during project list loading to minimize CLS
- adjust project results summary messaging to handle loading state cleanly

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d4c83585c88329be3359a3bb92eb2e