### PR TITLE
Add skip link and focus-visible styles for accessibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,6 +16,7 @@
     </script>
   </head>
   <body>
+    <a class="skip-link" href="#main">Skip to content</a>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,7 +28,9 @@ export default function App() {
   return (
     <>
       <CommandK items={COMMAND_ITEMS} />
-      <Portfolio />
+      <main id="main">
+        <Portfolio />
+      </main>
     </>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -59,9 +59,40 @@
   }
 
   * { @apply border-border; }
+  :focus-visible {
+    outline: 3px solid hsl(var(--ring));
+    outline-offset: 4px;
+  }
   body {
     @apply bg-background text-foreground antialiased;
     font-family: "Pretendard Variable", "Inter", "Noto Sans KR", system-ui, sans-serif;
+  }
+  .skip-link {
+    position: absolute;
+    top: 0;
+    left: 0;
+    transform: translateY(-100%);
+    padding: 0.75rem 1rem;
+    background-color: hsl(var(--background));
+    color: hsl(var(--foreground));
+    border: 2px solid hsl(var(--ring));
+    border-radius: 0.75rem;
+    box-shadow: 0 10px 30px hsl(var(--foreground) / 0.15);
+    clip: rect(0 0 0 0);
+    clip-path: inset(50%);
+    height: 1px;
+    width: 1px;
+    overflow: hidden;
+    white-space: nowrap;
+    z-index: 50;
+  }
+  .skip-link:focus-visible {
+    clip: auto;
+    clip-path: none;
+    height: auto;
+    width: auto;
+    transform: translateY(0);
+    margin: 1rem;
   }
   ::selection {
     background-color: hsl(var(--primary) / 0.15);


### PR DESCRIPTION
## Summary
- add a skip link at the top of the document for quick navigation to the main content
- wrap main app content in a semantic main element with an id for the skip target
- define a global focus-visible outline and skip-link visibility styles to clarify keyboard focus

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d4cd4956e88329b35721658befd982