### PR TITLE
Add section spy hook and back to top button

### DIFF
--- a/src/Portfolio.tsx
+++ b/src/Portfolio.tsx
@@ -26,6 +26,9 @@ import { Input } from "@/components/ui/input";
 import { Search, X } from "lucide-react";
 
 import LazyImage from "@/components/media/LazyImage";
+import { BackToTop } from "@/components/common/BackToTop";
+import useSectionSpy from "@/hooks/useSectionSpy";
+import { cn } from "@/lib/utils";
 
 
 
@@ -79,6 +82,13 @@ const SKILLS = [
   "Terraform", "Ansible", "Docker", "Nginx", "Prometheus/Grafana",
   "AWS", "GCP", "MySQL", "Python", "Streamlit"
 ];
+
+const NAV_ITEMS = [
+  { id: "about", label: "소개" },
+  { id: "projects", label: "프로젝트" },
+  { id: "skills", label: "기술스택" },
+  { id: "contact", label: "문의" },
+] as const;
 
 const STATS = [
   {
@@ -149,6 +159,9 @@ export default function Portfolio() {
   const [projects, setProjects] = React.useState<Project[]>([]);
   const [isLoading, setIsLoading] = React.useState(true);
 
+  const sectionIds = React.useMemo(() => NAV_ITEMS.map((item) => item.id), []);
+  const activeSection = useSectionSpy(sectionIds);
+
   React.useEffect(() => {
     setProjects(PROJECTS);
     setIsLoading(false);
@@ -186,10 +199,21 @@ export default function Portfolio() {
             <span>이동수 · DevOps & Cloud Architect</span>
           </div>
           <nav className="hidden md:flex items-center gap-4 text-sm">
-            <a href="#about" className="hover:text-primary">소개</a>
-            <a href="#projects" className="hover:text-primary">프로젝트</a>
-            <a href="#skills" className="hover:text-primary">기술스택</a>
-            <a href="#contact" className="hover:text-primary">문의</a>
+            {NAV_ITEMS.map((item) => (
+              <a
+                key={item.id}
+                href={`#${item.id}`}
+                className={cn(
+                  "relative px-1 py-2 transition-colors",
+                  activeSection === item.id
+                    ? "text-primary after:absolute after:bottom-1 after:left-0 after:h-0.5 after:w-full after:rounded-full after:bg-primary"
+                    : "text-muted-foreground hover:text-primary"
+                )}
+                aria-current={activeSection === item.id ? "true" : undefined}
+              >
+                {item.label}
+              </a>
+            ))}
           </nav>
           <div className="flex items-center gap-2">
             <ThemeToggle />
@@ -618,6 +642,7 @@ export default function Portfolio() {
           </div>
         </div>
       </footer>
+      <BackToTop />
     </div>
   );
 }

--- a/src/components/common/BackToTop.tsx
+++ b/src/components/common/BackToTop.tsx
@@ -1,0 +1,46 @@
+import * as React from "react";
+import { ArrowUp } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+const SHOW_AFTER = 600;
+
+export function BackToTop() {
+  const [isVisible, setIsVisible] = React.useState(false);
+
+  React.useEffect(() => {
+    const handleScroll = () => {
+      setIsVisible(window.scrollY > SHOW_AFTER);
+    };
+
+    handleScroll();
+    window.addEventListener("scroll", handleScroll, { passive: true });
+
+    return () => {
+      window.removeEventListener("scroll", handleScroll);
+    };
+  }, []);
+
+  const scrollToTop = React.useCallback(() => {
+    window.scrollTo({ top: 0, behavior: "smooth" });
+  }, []);
+
+  return (
+    <button
+      type="button"
+      onClick={scrollToTop}
+      aria-label="맨 위로 이동"
+      className={cn(
+        "fixed bottom-6 right-6 z-50 inline-flex h-12 w-12 items-center justify-center rounded-full bg-primary text-primary-foreground shadow-lg transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+        "hover:bg-primary/90",
+        isVisible
+          ? "pointer-events-auto translate-y-0 opacity-100"
+          : "pointer-events-none translate-y-4 opacity-0"
+      )}
+    >
+      <ArrowUp className="h-5 w-5" />
+    </button>
+  );
+}
+
+export default BackToTop;

--- a/src/hooks/useSectionSpy.ts
+++ b/src/hooks/useSectionSpy.ts
@@ -1,0 +1,100 @@
+import * as React from "react";
+
+type UseSectionSpyOptions = {
+  /**
+   * IntersectionObserver rootMargin. Defaults to "-45% 0px -45% 0px" to trigger near viewport center.
+   */
+  rootMargin?: string;
+  /**
+   * IntersectionObserver thresholds. Defaults to [0, 0.1, 0.25, 0.5, 0.75, 1].
+   */
+  thresholds?: number[];
+};
+
+/**
+ * Observe the provided section IDs and return the section currently in view.
+ */
+export function useSectionSpy(
+  sectionIds: string[],
+  { rootMargin = "-45% 0px -45% 0px", thresholds = [0, 0.1, 0.25, 0.5, 0.75, 1] }: UseSectionSpyOptions = {}
+) {
+  const [activeId, setActiveId] = React.useState(() => sectionIds[0] ?? "");
+  const visibleSectionsRef = React.useRef(new Set<string>());
+
+  React.useEffect(() => {
+    if (!sectionIds.length) {
+      setActiveId("");
+      return;
+    }
+
+    const visibleSections = visibleSectionsRef.current;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        let shouldUpdate = false;
+
+        entries.forEach((entry) => {
+          const { id } = entry.target;
+
+          if (entry.isIntersecting) {
+            if (!visibleSections.has(id)) {
+              visibleSections.add(id);
+              shouldUpdate = true;
+            }
+          } else if (visibleSections.has(id)) {
+            visibleSections.delete(id);
+            shouldUpdate = true;
+          }
+        });
+
+        if (shouldUpdate) {
+          const orderedVisible = sectionIds.find((id) => visibleSections.has(id));
+
+          if (orderedVisible) {
+            setActiveId(orderedVisible);
+            return;
+          }
+
+          // No section is intersecting. Fallback to the nearest section to the top of the viewport.
+          const nearest = sectionIds
+            .map((id) => {
+              const element = document.getElementById(id);
+              if (!element) {
+                return { id, distance: Number.POSITIVE_INFINITY };
+              }
+              const rect = element.getBoundingClientRect();
+              return { id, distance: Math.abs(rect.top) };
+            })
+            .reduce((closest, current) =>
+              current.distance < closest.distance ? current : closest
+            );
+
+          if (nearest.distance !== Number.POSITIVE_INFINITY) {
+            setActiveId(nearest.id);
+          }
+        }
+      },
+      {
+        root: null,
+        rootMargin,
+        threshold: thresholds,
+      }
+    );
+
+    const elements = sectionIds
+      .map((id) => document.getElementById(id))
+      .filter((element): element is HTMLElement => Boolean(element));
+
+    elements.forEach((element) => observer.observe(element));
+
+    return () => {
+      visibleSections.clear();
+      elements.forEach((element) => observer.unobserve(element));
+      observer.disconnect();
+    };
+  }, [rootMargin, sectionIds, thresholds]);
+
+  return activeId;
+}
+
+export default useSectionSpy;


### PR DESCRIPTION
## Summary
- add reusable `useSectionSpy` hook for tracking the active section while scrolling
- highlight portfolio navigation links using the active section id
- introduce a floating back-to-top button that appears after scrolling

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d4cf12d7308329a10f2482f8ffb9f4