### PR TITLE
feat: animate project cards with framer motion

### DIFF
--- a/src/Portfolio.tsx
+++ b/src/Portfolio.tsx
@@ -22,6 +22,7 @@ import { Separator } from "@/components/ui/separator";
 import { ThemeToggle } from "@/components/ThemeToggle";
 
 import CardSkeleton from "@/components/skeleton/CardSkeleton";
+import ProjectCard from "@/components/ProjectCard";
 import { Input } from "@/components/ui/input";
 import { Search, X } from "lucide-react";
 
@@ -524,48 +525,15 @@ export default function Portfolio() {
         ) : filtered.length ? (
           <div className="grid md:grid-cols-3 gap-6">
             {filtered.map((p, idx) => (
-              <motion.div
+              <ProjectCard
                 key={p.title}
-                className="group h-full"
-                initial={{ opacity: 0, y: 14 }}
-                whileInView={{ opacity: 1, y: 0 }}
-                viewport={{ once: true, amount: 0.3 }}
-                transition={{ duration: 0.4, delay: idx * 0.05 }}
-                whileHover={{ y: -8 }}
-              >
-                <Card className="relative h-full overflow-hidden rounded-2xl border border-primary/15 bg-gradient-to-br from-background/90 via-primary/5 to-background/95 shadow-lg transition-shadow group-hover:shadow-2xl">
-                  <div className="pointer-events-none absolute inset-0 z-0 opacity-0 transition-opacity duration-500 group-hover:opacity-100">
-                    <div className="absolute inset-0 bg-gradient-to-br from-primary/15 via-sky-500/15 to-purple-500/20" />
-                  </div>
-                  <LazyImage
-                    src={p.image}
-                    alt={`${p.title} 프로젝트 썸네일 이미지`}
-                    containerClassName="relative z-10 aspect-video w-full bg-gradient-to-br from-background via-muted/40 to-background"
-                    className="object-contain p-4"
-                    skeletonClassName="bg-muted/60"
-                  />
-                  <CardHeader className="relative z-20 space-y-2 px-6 pt-6 pb-3">
-                    <CardTitle className="text-lg transition-colors group-hover:text-primary">{p.title}</CardTitle>
-                    <CardDescription className="leading-relaxed">{p.desc}</CardDescription>
-                  </CardHeader>
-                  <CardContent className="relative z-20 space-y-4">
-                    <div className="flex flex-wrap gap-2">
-                      {p.tags.map((t) => (
-                        <Badge key={t} variant="secondary" className="rounded-xl border border-primary/10 bg-primary/5 text-foreground">
-                          {t}
-                        </Badge>
-                      ))}
-                    </div>
-                    <div className="flex justify-end">
-                      <Button asChild variant="ghost" size="sm" className="rounded-xl text-primary hover:text-primary">
-                        <a href={p.href ?? "#"} target="_blank" rel="noreferrer">
-                          상세 보기
-                        </a>
-                      </Button>
-                    </div>
-                  </CardContent>
-                </Card>
-              </motion.div>
+                title={p.title}
+                description={p.desc}
+                tags={p.tags}
+                image={p.image}
+                href={p.href}
+                index={idx}
+              />
             ))}
           </div>
         ) : (

--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -1,0 +1,93 @@
+import { motion } from "framer-motion";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import LazyImage from "@/components/media/LazyImage";
+import { cn } from "@/lib/utils";
+
+export interface ProjectCardProps {
+  title: string;
+  description: string;
+  tags: string[];
+  image: string;
+  href?: string;
+  index?: number;
+  className?: string;
+}
+
+const fadeUp = {
+  initial: { opacity: 0, y: 16 },
+  animate: { opacity: 1, y: 0 },
+};
+
+export default function ProjectCard({
+  title,
+  description,
+  tags,
+  image,
+  href,
+  index = 0,
+  className,
+}: ProjectCardProps) {
+  return (
+    <motion.div
+      role="group"
+      tabIndex={0}
+      className={cn(
+        "group relative h-full rounded-2xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50 focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+        className,
+      )}
+      variants={fadeUp}
+      initial="initial"
+      whileInView="animate"
+      viewport={{ once: true, amount: 0.3 }}
+      transition={{
+        duration: 0.2,
+        delay: index * 0.05,
+        ease: "easeOut",
+      }}
+      whileHover={{
+        scale: 1.02,
+        transition: { duration: 0.18, ease: "easeOut" },
+      }}
+      whileFocus={{
+        scale: 1.02,
+        transition: { duration: 0.18, ease: "easeOut" },
+      }}
+    >
+      <Card className="relative h-full overflow-hidden rounded-2xl border border-primary/15 bg-gradient-to-br from-background/90 via-primary/5 to-background/95 shadow-lg transition-shadow group-hover:shadow-2xl group-focus-visible:shadow-2xl">
+        <div className="pointer-events-none absolute inset-0 z-0 opacity-0 transition-opacity duration-500 group-hover:opacity-100 group-focus-visible:opacity-100">
+          <div className="absolute inset-0 bg-gradient-to-br from-primary/15 via-sky-500/15 to-purple-500/20" />
+        </div>
+        <LazyImage
+          src={image}
+          alt={`${title} 프로젝트 썸네일 이미지`}
+          containerClassName="relative z-10 aspect-video w-full bg-gradient-to-br from-background via-muted/40 to-background"
+          className="object-contain p-4"
+          skeletonClassName="bg-muted/60"
+        />
+        <CardHeader className="relative z-20 space-y-2 px-6 pt-6 pb-3">
+          <CardTitle className="text-lg transition-colors group-hover:text-primary group-focus-visible:text-primary">{title}</CardTitle>
+          <CardDescription className="leading-relaxed">{description}</CardDescription>
+        </CardHeader>
+        <CardContent className="relative z-20 space-y-4">
+          <div className="flex flex-wrap gap-2">
+            {tags.map((tag) => (
+              <Badge key={tag} variant="secondary" className="rounded-xl border border-primary/10 bg-primary/5 text-foreground">
+                {tag}
+              </Badge>
+            ))}
+          </div>
+          <div className="flex justify-end">
+            <Button asChild variant="ghost" size="sm" className="rounded-xl text-primary hover:text-primary">
+              <a href={href ?? "#"} target="_blank" rel="noreferrer">
+                상세 보기
+              </a>
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    </motion.div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a reusable ProjectCard component that wraps each card in framer-motion for fade-up entrance and hover/focus scale interactions
- refactor the portfolio project grid to use the animated ProjectCard for consistent presentation

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d4d30dd4908329893a909b4191d8d9