### PR TITLE
feat: enhance SEO metadata

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,63 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/ci-ds.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>ds portfolio by Vite + React + TS</title>
+    <title>이동수 | DevOps & Cloud Engineer 포트폴리오</title>
+    <meta
+      name="description"
+      content="DevOps & Cloud Engineer 이동수의 포트폴리오. Kubernetes와 AWS/GCP 기반 인프라 설계, CI/CD 자동화 경험을 확인하세요."
+    />
+    <meta property="og:locale" content="ko_KR" />
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="이동수 포트폴리오" />
+    <meta property="og:title" content="이동수 | DevOps & Cloud Engineer 포트폴리오" />
+    <meta
+      property="og:description"
+      content="DevOps & Cloud Engineer 이동수의 포트폴리오. Kubernetes와 AWS/GCP 기반 인프라 설계, CI/CD 자동화 경험을 확인하세요."
+    />
+    <meta property="og:url" content="https://github.com/dslee1371" />
+    <meta
+      property="og:image"
+      content="https://raw.githubusercontent.com/dslee1371/ds-portfolio-app/main/public/ci-ds.svg"
+    />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:alt" content="이동수 DevOps & Cloud Engineer 브랜드 아이콘" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="이동수 | DevOps & Cloud Engineer 포트폴리오" />
+    <meta
+      name="twitter:description"
+      content="DevOps & Cloud Engineer 이동수의 포트폴리오. Kubernetes와 AWS/GCP 기반 인프라 설계, CI/CD 자동화 경험을 확인하세요."
+    />
+    <meta
+      name="twitter:image"
+      content="https://raw.githubusercontent.com/dslee1371/ds-portfolio-app/main/public/ci-ds.svg"
+    />
+    <meta name="twitter:image:alt" content="이동수 DevOps & Cloud Engineer 브랜드 아이콘" />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "Person",
+        "name": "이동수",
+        "jobTitle": "DevOps & Cloud Engineer",
+        "url": "https://github.com/dslee1371",
+        "description": "Kubernetes, AWS/GCP 기반 인프라 설계와 CI/CD 파이프라인 자동화를 수행하는 DevOps & Cloud Architect",
+        "email": "mailto:dslee1371@gmail.com",
+        "image": "https://raw.githubusercontent.com/dslee1371/ds-portfolio-app/main/public/ci-ds.svg",
+        "sameAs": [
+          "https://github.com/dslee1371",
+          "mailto:dslee1371@gmail.com"
+        ],
+        "knowsAbout": [
+          "DevOps",
+          "Site Reliability Engineering",
+          "Kubernetes",
+          "Cloud Architecture"
+        ],
+        "worksFor": {
+          "@type": "Organization",
+          "name": "Freelance / Consulting"
+        }
+      }
+    </script>
     <script>
       (function() {
         const key = "theme";

--- a/src/Portfolio.tsx
+++ b/src/Portfolio.tsx
@@ -32,6 +32,10 @@ const ProjectsSection = React.lazy(() => import("./sections/ProjectsSection"));
 const SkillsSection = React.lazy(() => import("./sections/SkillsSection"));
 const ContactSection = React.lazy(() => import("./sections/ContactSection"));
 
+const SEO_TITLE = "이동수 | DevOps & Cloud Engineer 포트폴리오";
+const SEO_DESCRIPTION =
+  "DevOps & Cloud Engineer 이동수의 포트폴리오. Kubernetes와 AWS/GCP 기반 인프라 설계, CI/CD 자동화 경험을 확인하세요.";
+
 const SECTION_PREFETCHERS: Record<string, () => Promise<unknown>> = {
   about: () => import("./sections/AboutSection"),
   projects: () => import("./sections/ProjectsSection"),
@@ -76,6 +80,23 @@ export default function Portfolio() {
     if (loader) {
       void loader();
     }
+  }, []);
+
+  React.useEffect(() => {
+    document.title = SEO_TITLE;
+
+    const setMetaContent = (selector: string, content: string) => {
+      const element = document.querySelector<HTMLMetaElement>(selector);
+      if (element) {
+        element.setAttribute("content", content);
+      }
+    };
+
+    setMetaContent('meta[name="description"]', SEO_DESCRIPTION);
+    setMetaContent('meta[property="og:title"]', SEO_TITLE);
+    setMetaContent('meta[property="og:description"]', SEO_DESCRIPTION);
+    setMetaContent('meta[name="twitter:title"]', SEO_TITLE);
+    setMetaContent('meta[name="twitter:description"]', SEO_DESCRIPTION);
   }, []);
 
   return (


### PR DESCRIPTION
## Summary
- add comprehensive Open Graph, Twitter card, and JSON-LD metadata to the base HTML entrypoint for richer sharing previews
- synchronize document title and meta descriptions from the portfolio page to keep single-page navigation SEO friendly

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4edca157c8329bc8afddbc87bb809