### PR TITLE
Improve typography rhythm and reading width

### DIFF
--- a/src/Portfolio.tsx
+++ b/src/Portfolio.tsx
@@ -134,6 +134,7 @@ export default function Portfolio() {
             initial={{ opacity: 0, y: 14 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.5 }}
+            className="max-w-[72ch]"
           >
             <Badge
               variant="secondary"
@@ -141,10 +142,10 @@ export default function Portfolio() {
             >
               SRE · DevOps · Cloud Architecture
             </Badge>
-            <h1 className="text-3xl sm:text-4xl md:text-5xl font-bold tracking-tight leading-tight">
+            <h1 className="font-bold tracking-tight text-balance">
               안녕하세요, <span className="bg-gradient-to-r from-primary via-sky-500 to-purple-500 bg-clip-text text-transparent">이동수</span>입니다.
             </h1>
-            <p className="mt-4 text-muted-foreground text-lg leading-relaxed">
+            <p className="mt-4 text-muted-foreground leading-relaxed">
               Python 기반 CI/CD 파이프라인과 Kubernetes, AWS/GCP 인프라스트럭처를 토대로
               미션 크리티컬 서비스를 설계하고 자동화하는 DevOps/클라우드 아키텍트입니다.
               복잡한 운영 환경을 구조화된 표준과 코드 중심 거버넌스로 정렬합니다.
@@ -214,7 +215,7 @@ export default function Portfolio() {
               />
               <CardContent className="relative z-10 p-6 pt-6 md:p-8 md:pt-6">
                 <p className="text-sm uppercase tracking-wider text-muted-foreground">Core Focus</p>
-                <h2 className="mt-2 text-2xl font-semibold leading-tight">
+                <h2 className="mt-2 font-semibold leading-tight text-balance">
                   안정성과 민첩성을 균형화한
                   <span className="ml-1 bg-gradient-to-r from-primary via-sky-500 to-purple-500 bg-clip-text text-transparent">
                     운영 전략 프레임워크

--- a/src/index.css
+++ b/src/index.css
@@ -63,9 +63,52 @@
     outline: 3px solid hsl(var(--ring));
     outline-offset: 4px;
   }
+  :root {
+    --reading-max: min(72ch, 100%);
+  }
+
   body {
     @apply bg-background text-foreground antialiased;
     font-family: "Pretendard Variable", "Inter", "Noto Sans KR", system-ui, sans-serif;
+    font-size: clamp(1rem, 0.96rem + 0.35vw, 1.125rem);
+    line-height: 1.65;
+  }
+
+  h1 {
+    font-size: clamp(2.5rem, 2rem + 2.6vw, 3.5rem);
+    line-height: 1.1;
+    letter-spacing: -0.015em;
+  }
+
+  h2 {
+    font-size: clamp(1.875rem, 1.55rem + 1.4vw, 2.75rem);
+    line-height: 1.25;
+    letter-spacing: -0.01em;
+  }
+
+  p,
+  ul,
+  ol,
+  blockquote {
+    max-width: var(--reading-max);
+  }
+
+  p {
+    margin-block: 0;
+  }
+
+  p + p,
+  p + ul,
+  p + ol,
+  ul + p,
+  ol + p,
+  blockquote + p,
+  p + blockquote {
+    margin-top: clamp(1rem, 0.9rem + 0.4vw, 1.6rem);
+  }
+
+  li {
+    line-height: 1.6;
   }
   .skip-link {
     position: absolute;

--- a/src/sections/AboutSection.tsx
+++ b/src/sections/AboutSection.tsx
@@ -25,10 +25,10 @@ export default function AboutSection() {
     <section id="about" className="mx-auto max-w-6xl px-4 py-8">
       <div className="grid md:grid-cols-3 gap-8">
         <div>
-          <h2 className="text-2xl font-bold">소개</h2>
+          <h2 className="font-bold text-balance">소개</h2>
           <p className="mt-2 text-muted-foreground">Who I am</p>
         </div>
-        <div className="md:col-span-2 space-y-4 leading-relaxed">
+        <div className="md:col-span-2 space-y-4 leading-relaxed max-w-[72ch]">
           <p>
             대기업과 금융권 환경에서 Kubernetes 중심의 운영 플랫폼, CI/CD 체계, IaC·Observability 프레임워크를 설계하고 고도화했습니다.
             네트워크·보안·배포 파이프라인을 통합 설계해 복잡한 운영 이슈를 신속하게 안정화합니다.

--- a/src/sections/ContactSection.tsx
+++ b/src/sections/ContactSection.tsx
@@ -13,8 +13,8 @@ export default function ContactSection() {
           <Badge variant="outline" className="w-fit rounded-xl">
             Let's talk
           </Badge>
-          <CardTitle className="text-3xl">프로젝트 컨설팅 문의</CardTitle>
-          <CardDescription className="max-w-2xl text-base text-muted-foreground">
+          <CardTitle className="text-balance">프로젝트 컨설팅 문의</CardTitle>
+          <CardDescription className="max-w-[72ch] text-base text-muted-foreground">
             핵심 요구사항을 공유해 주시면 비즈니스 목표와 우선순위에 맞춘 실행 전략을 설계해 드립니다.
           </CardDescription>
         </CardHeader>

--- a/src/sections/ExperienceSection.tsx
+++ b/src/sections/ExperienceSection.tsx
@@ -43,8 +43,8 @@ export default function ExperienceSection() {
   return (
     <section className="mx-auto max-w-6xl px-4 py-10">
       <div className="grid gap-6 md:grid-cols-[280px_1fr]">
-        <div>
-          <h2 className="text-2xl font-bold">경력 하이라이트</h2>
+        <div className="max-w-[72ch]">
+          <h2 className="font-bold text-balance">경력 하이라이트</h2>
           <p className="mt-2 text-muted-foreground text-sm">
             팀 조직화부터 배포 자동화, 관측성 확보까지 엔드투엔드로 주도한 프로그램을 요약했습니다.
           </p>

--- a/src/sections/ProjectsSection.tsx
+++ b/src/sections/ProjectsSection.tsx
@@ -67,7 +67,7 @@ export default function ProjectsSection() {
 
   return (
     <section id="projects" className="mx-auto max-w-6xl px-4 py-8">
-      <h2 className="text-2xl font-bold mb-4">선정 프로젝트</h2>
+      <h2 className="mb-4 font-bold text-balance">선정 프로젝트</h2>
 
       <div className="mb-4 flex flex-col gap-3">
         <div className="relative">

--- a/src/sections/SkillsSection.tsx
+++ b/src/sections/SkillsSection.tsx
@@ -23,7 +23,7 @@ const SKILLS = [
 export default function SkillsSection() {
   return (
     <section id="skills" className="mx-auto max-w-6xl px-4 py-8">
-      <h2 className="text-2xl font-bold mb-6">기술 스택</h2>
+      <h2 className="mb-6 font-bold text-balance">기술 스택</h2>
       <div className="grid sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3">
         {SKILLS.map((skill) => (
           <motion.div


### PR DESCRIPTION
## Summary
- add fluid clamp-based typography scales for headings and body text to improve rhythm across breakpoints
- standardize paragraph spacing and introduce a reusable reading-width constraint
- apply the new reading width and text balance utilities across key sections for consistent readability

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d4f03dddb8832997b169a1d1f6eed5