### PR TITLE
feat: extend command search index

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,32 +1,10 @@
 import React from "react";
-import CommandK, { type CommandKItem } from "@/components/command/CommandK";
+import CommandK from "@/components/command/CommandK";
 import { AnimatePresence, motion } from "framer-motion";
 import { useLocation } from "react-router-dom";
+import { COMMAND_ITEMS } from "@/lib/search-index";
 
 const Portfolio = React.lazy(() => import("./Portfolio"));
-
-const COMMAND_ITEMS: CommandKItem[] = [
-  {
-    label: "Home",
-    path: "/",
-    keywords: ["home", "start", "hero", "메인"],
-  },
-  {
-    label: "Projects",
-    path: "/#projects",
-    keywords: ["project", "work", "case study", "프로젝트"],
-  },
-  {
-    label: "About",
-    path: "/#about",
-    keywords: ["about", "profile", "career", "소개"],
-  },
-  {
-    label: "Contact",
-    path: "/#contact",
-    keywords: ["contact", "email", "연락", "문의"],
-  },
-];
 
 export default function App() {
   const location = useLocation();

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -1,0 +1,33 @@
+export type Project = {
+  title: string
+  desc: string
+  tags: string[]
+  href: string
+  image: string
+}
+
+export const PROJECTS: Project[] = [
+  {
+    title: "Binance 자동 매매 시스템",
+    desc: "Python · FastAPI · MySQL · Futures API · 리스크 헤지 엔진 · Kubernetes 오케스트레이션",
+    tags: ["Python", "Binance", "MySQL", "Kubernetes", "Prometheus"],
+    href: "#",
+    image: "/ci-ds.svg",
+  },
+  {
+    title: "네이버 부동산 스크래퍼",
+    desc: "Streamlit 대시보드 · ETL 크롤러 · Prometheus 메트릭스 · 자동화 배포 파이프라인",
+    tags: ["Streamlit", "GitOps", "Grafana", "Docker"],
+    href: "#",
+    image: "/vite.svg",
+  },
+  {
+    title: "KCB DR 환경 구축",
+    desc: "AWS 다계정(EKS/EC2) · Argo CD · Helm 차트 · 엔터프라이즈 CI/CD 파이프라인",
+    tags: ["AWS", "EKS", "Argo CD", "Helm"],
+    href: "#",
+    image: "/ci-ds.svg",
+  },
+]
+
+export const PROJECT_TAGS = Array.from(new Set(PROJECTS.flatMap((project) => project.tags))).sort()

--- a/src/lib/search-index.ts
+++ b/src/lib/search-index.ts
@@ -1,0 +1,94 @@
+import type { CommandKItem } from "@/components/command/CommandK"
+import { PROJECTS, PROJECT_TAGS } from "@/data/projects"
+
+function uniqueKeywords(...groups: Array<string | string[] | undefined>): string[] {
+  const set = new Set<string>()
+  for (const group of groups) {
+    if (!group) continue
+    if (Array.isArray(group)) {
+      group.forEach((value) => {
+        const normalized = value.trim()
+        if (normalized) {
+          set.add(normalized)
+        }
+      })
+    } else {
+      const normalized = group.trim()
+      if (normalized) {
+        set.add(normalized)
+      }
+    }
+  }
+  return Array.from(set)
+}
+
+function createProjectKeywords(description: string, tags: string[]): string[] {
+  const segments = description
+    .split(/[·,]/)
+    .map((segment) => segment.trim())
+    .filter(Boolean)
+  const words = segments.flatMap((segment) =>
+    segment
+      .split(/\s+/)
+      .map((part) => part.trim())
+      .filter(Boolean)
+  )
+
+  return uniqueKeywords(
+    "project",
+    "프로젝트",
+    description,
+    segments,
+    words,
+    tags,
+  )
+}
+
+const PAGE_ITEMS: CommandKItem[] = [
+  {
+    label: "Home",
+    to: "/",
+    keywords: ["home", "start", "hero", "메인", "홈", "메인 화면"],
+    description: "랜딩 페이지 및 주요 소개",
+  },
+  {
+    label: "Projects",
+    to: "/#projects",
+    keywords: ["project", "work", "case study", "프로젝트", "포트폴리오"],
+    description: "선정 프로젝트 리스트",
+  },
+  {
+    label: "About",
+    to: "/#about",
+    keywords: ["about", "profile", "career", "소개", "경력"],
+    description: "이력 및 소개 섹션",
+  },
+  {
+    label: "Skills",
+    to: "/#skills",
+    keywords: ["skill", "stack", "tech", "기술", "스킬", "역량"],
+    description: "핵심 기술 스택",
+  },
+  {
+    label: "Contact",
+    to: "/#contact",
+    keywords: ["contact", "email", "연락", "문의", "상담"],
+    description: "연락처 및 상담 요청",
+  },
+]
+
+const PROJECT_ITEMS: CommandKItem[] = PROJECTS.map((project) => ({
+  label: project.title,
+  to: "/#projects",
+  keywords: uniqueKeywords(project.title, createProjectKeywords(project.desc, project.tags)),
+  description: project.desc,
+}))
+
+const TAG_ITEMS: CommandKItem[] = PROJECT_TAGS.map((tag) => ({
+  label: `Tag · ${tag}`,
+  to: "/#projects",
+  keywords: uniqueKeywords("tag", "태그", "프로젝트", tag),
+  description: `${tag} 관련 프로젝트 태그`,
+}))
+
+export const COMMAND_ITEMS: CommandKItem[] = [...PAGE_ITEMS, ...PROJECT_ITEMS, ...TAG_ITEMS]

--- a/src/sections/ProjectsSection.tsx
+++ b/src/sections/ProjectsSection.tsx
@@ -4,32 +4,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import CardSkeleton from "@/components/skeleton/CardSkeleton";
 import ProjectCard from "@/components/ProjectCard";
-
-const PROJECTS = [
-  {
-    title: "Binance 자동 매매 시스템",
-    desc: "Python · FastAPI · MySQL · Futures API · 리스크 헤지 엔진 · Kubernetes 오케스트레이션",
-    tags: ["Python", "Binance", "MySQL", "Kubernetes", "Prometheus"],
-    href: "#",
-    image: "/ci-ds.svg",
-  },
-  {
-    title: "네이버 부동산 스크래퍼",
-    desc: "Streamlit 대시보드 · ETL 크롤러 · Prometheus 메트릭스 · 자동화 배포 파이프라인",
-    tags: ["Streamlit", "GitOps", "Grafana", "Docker"],
-    href: "#",
-    image: "/vite.svg",
-  },
-  {
-    title: "KCB DR 환경 구축",
-    desc: "AWS 다계정(EKS/EC2) · Argo CD · Helm 차트 · 엔터프라이즈 CI/CD 파이프라인",
-    tags: ["AWS", "EKS", "Argo CD", "Helm"],
-    href: "#",
-    image: "/ci-ds.svg",
-  },
-];
-
-const ALL_TAGS = Array.from(new Set(PROJECTS.flatMap((p) => p.tags))).sort();
+import { PROJECTS, PROJECT_TAGS } from "@/data/projects";
 
 export default function ProjectsSection() {
   const [query, setQuery] = React.useState("");
@@ -96,7 +71,7 @@ export default function ProjectsSection() {
         </div>
 
         <div className="flex flex-wrap gap-2">
-          {ALL_TAGS.map((tag) => {
+          {PROJECT_TAGS.map((tag) => {
             const on = activeTags.has(tag);
             return (
               <button


### PR DESCRIPTION
## Summary
- centralize project metadata so it can populate the command palette search index
- extend CommandK filtering to handle multi-term queries with keyword highlighting
- surface the aggregated search items through the app so pages, projects, and tags are searchable from one place

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4f599c49083299b4fe3d0e7a28de2