### PR TITLE
fix: remove pulse animation from lazy image placeholder

### DIFF
--- a/src/components/media/LazyImage.tsx
+++ b/src/components/media/LazyImage.tsx
@@ -59,7 +59,7 @@ const LazyImage = React.forwardRef<HTMLImageElement, LazyImageProps>(
         <div
           aria-hidden
           className={cn(
-            "pointer-events-none absolute inset-0 animate-pulse bg-muted transition-opacity duration-300",
+            "pointer-events-none absolute inset-0 bg-muted transition-opacity duration-300",
             isLoaded && "opacity-0",
             skeletonClassName,
           )}


### PR DESCRIPTION
## Summary
- remove the pulse animation from the lazy image placeholder so it no longer flickers while loading

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db78adaac483298ebe4a3d3a983547